### PR TITLE
Add workflow concurrency config

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -6,6 +6,10 @@ on:
   pull_request_review_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   bonk:
     if: github.event.sender.type != 'Bot'


### PR DESCRIPTION
Adds a top-level `concurrency` block to prevent overlapping Bonk workflow runs on the same issue/PR.

- groups runs by workflow name + issue/PR number
- `cancel-in-progress: false` ensures running jobs complete before new ones start